### PR TITLE
Time of day fix.

### DIFF
--- a/src/components/WeatherIcon.js
+++ b/src/components/WeatherIcon.js
@@ -1,7 +1,8 @@
 import React from 'react';
 
 function WeatherIcon(props) {
-  let timeOfDay = (new Date().getHours() > 19) ? 'night' : 'day';
+  let currentTime = new Date().getHours();
+  let timeOfDay = (currentTime >= 6 && currentTime < 19) ? 'day' : 'night';
   return (
     <p className={`wi wi-owm-${timeOfDay}-${props.weatherIconCode} text-center weatherIcon`}></p>
   )


### PR DESCRIPTION
## Description

Modified the logic for displaying the icon based on the time of day. Found out that it would display the icon for `day` after midnight because I was only checking if it was `> 19`.

### Tech change

- Added a time range (sort of) to display the icon. It now checks if `currentTime >= 6` (i. e. 0600 hrs) and `currentTime < 19` (i. e. 1900 hrs).